### PR TITLE
logging: Forward container logs to dlt-daemon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,9 @@ else
 endif
 
 override LIBS += $(shell $(PKG_CONFIG) --libs glib-2.0)
+override LIBS += "-ldlt"
 
-CFLAGS ?= -std=c99 -Os -Wall -Wextra -Werror
+CFLAGS ?= -std=c99 -Os -Wall -Wextra -Werror -Wno-unused-parameter
 override CFLAGS += $(shell $(PKG_CONFIG) --cflags glib-2.0) -DVERSION=\"$(VERSION)\" -DGIT_COMMIT=\"$(GIT_COMMIT)\"
 
 # Conditionally compile journald logging code if the libraries can be found

--- a/src/conmon.c
+++ b/src/conmon.c
@@ -365,6 +365,8 @@ int main(int argc, char *argv[])
 		}
 	}
 
+	register_dlt();
+
 	if (!WIFEXITED(runtime_status) || WEXITSTATUS(runtime_status) != 0) {
 		/*
 		 * Read from container stderr for any error and send it to parent

--- a/src/ctr_logging.h
+++ b/src/ctr_logging.h
@@ -11,5 +11,6 @@ void configure_log_drivers(gchar **log_drivers, int64_t log_size_max_, int64_t l
 void sync_logs(void);
 gboolean logging_is_passthrough(void);
 void close_logging_fds(void);
+void register_dlt(void);
 
 #endif /* !defined(CTR_LOGGING_H) */


### PR DESCRIPTION
The drivers 'k8s-file' and 'journald' will work as before, but the logs will additionally be forwarded to dlt-daemon